### PR TITLE
Double quote YAML strings

### DIFF
--- a/config-merge.js
+++ b/config-merge.js
@@ -238,7 +238,10 @@ if (format == "json") {
         }
     })
 } else {
-    serialized = YAML.stringify(obj, options={simpleKeys: true})
+    serialized = YAML.stringify(obj, {
+        defaultStringType: 'QUOTE_DOUBLE',
+        simpleKeys: true
+    })
 }
 
 if (format == "json" || format == "json5" || format == "toml") {


### PR DESCRIPTION
`config-merge` uses [YAML.stringify()](https://eemeli.org/yaml/#yaml-stringify) to format the merged output as YAML.

While `YAML.stringify()` outputs YAML version **1.2** by default (https://eemeli.org/yaml/#document-options), the merged output may be consumed/parsed by other applications that expect YAML version **1.1**. This is normally not an issue, except when it comes to `yes`/`no` strings. By default, `YAML.stringify()` formats strings unquoted. YAML version **1.2** parses unquoted `yes`/`no` strings as strings, while YAML version **1.1** parses unquoted `yes`/`no` strings as `true`/`false` booleans (https://eemeli.org/yaml/#version-differences).

An easy solution is to configure `YAML.stringify()` to double-quote all strings by default, by setting `defaultStringType` to `QUOTE_DOUBLE` (https://eemeli.org/yaml/#tostring-options). This will have no impact on YAML version **1.2** parsers, but fixes the issue with YAML version **1.1** parsers when it comes to `yes`/`no` strings.