### PR TITLE
Added support for JSON5 files

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,23 +2,24 @@
 
 ![test](https://github.com/boxboat/config-merge/workflows/test/badge.svg)
 
-Tool for merging JSON/TOML/YAML files and performing environment variable substitution.  Runs in a Docker Container.
+Tool for merging JSON/JSON5/TOML/YAML files and performing environment variable substitution.  Runs in a Docker Container.
 
 ## Usage
 
 `config-merge` is released on [DockerHub](https://hub.docker.com/r/boxboat/config-merge/).  Usage can be seen by running with the `-h` flag
 
-```
-docker pull boxboat/config-merge
-docker run --rm boxboat/config-merge -h
+```bash
+$ docker pull boxboat/config-merge
+$ docker run --rm boxboat/config-merge -h
 
-boxboat/config-merge [-fnh] file1 [file2] ... [fileN]
--a, --array    merge|overwrite|concat   whether to merge, overwrite, or concatenate arrays.  defaults to merge
--f, --format   json|toml|yaml           whether to output json, toml, or yaml.  defaults to yaml
--h  --help     print the help message
+boxboat/config-merge [flags] file1 [file2] ... [fileN]
+-a, --array         merge|overwrite|concat   whether to merge, overwrite, or concatenate arrays.  defaults to merge
+-f, --format        json|json5|toml|yaml   whether to output json, json5, toml, or yaml.  defaults to yaml
+-h  --help          print the help message
+    --no-envsubst   disable substituting env vars
     files ending in .env and .sh will be sourced and used for environment variable substitution
-    files ending in .json, .js, .toml, .yaml, and .yml will be merged
-    files ending in .patch.json, .patch.js, .patch.toml, .patch.yaml, and .patch.yml will be applied as JSONPatch
+    files ending in .json, .js, .json5, .toml, .yaml, and .yml will be merged
+    files ending in .patch.json, .patch.js, .patch.json5, .patch.toml, .patch.yaml, and .patch.yml will be applied as JSONPatch
 ```
 
 The working directory of the container is `/home/node` and files/directories that get merged should be mounted into this directory.
@@ -27,7 +28,7 @@ The working directory of the container is `/home/node` and files/directories tha
 
 This example considers building a Docker Compose file that can be used for production, but also tested locally.  The production compose file contains an extra network that is not available to the local developer.  We are able to use the patching feature of `config-merge` to remove the unneeded network, and use the environment variable substitution feature to add a custom network.
 
-```
+```bash
 docker_compose_config=$(
     docker run --rm \
     -v "$(pwd)/test/docker-compose/:/home/node/" \
@@ -48,7 +49,7 @@ EOF
 
 Globbing is supported, but should be escaped in the `docker run` script so that expansion will occur inside of the container:
 
-```
+```bash
 docker_compose_config=$(
     docker run --rm \
     -v "$(pwd)/test/docker-compose/:/home/node/" \
@@ -59,7 +60,7 @@ docker_compose_config=$(
 
 ## Merging
 
-Files ending in `.json`, `.js`, `.toml`, `.yaml`, and `.yml` are merged together.  The merging algorithm uses the [lodash merge](https://lodash.com/docs/4.17.4#merge) function and operates:
+Files ending in `.json`, `.js`, `.json5`, `.toml`, `.yaml`, and `.yml` are merged together.  The merging algorithm uses the [lodash merge](https://lodash.com/docs/4.17.4#merge) function and operates:
 
 > Source properties that resolve to undefined are skipped if a destination value exists. Array and plain object properties are merged recursively. Other objects and value types are overridden by assignment. Source objects are applied from left to right. Subsequent sources overwrite property assignments of previous sources.
 
@@ -67,7 +68,7 @@ Use the `-a`/`--array` argument to configure the merging behavior for arrays.
 
 ## Patching
 
-Files ending in `.patch.json`, `.patch.js`, `.patch.toml`, `.patch.yaml`, and `.patch.yml` are applied as [JSON Patch](http://jsonpatch.com/)
+Files ending in `.patch.json`, `.patch.js`, `.patch.json5`, `.patch.toml`, `.patch.yaml`, and `.patch.yml` are applied as [JSON Patch](http://jsonpatch.com/)
 
 ## Environment Variable Substitution
 

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "dependencies": {
     "fast-json-patch": "3.1.1",
     "glob": "7.1.2",
+    "json5": "2.2.3",
     "lodash.mergewith": "4.6.2",
     "toml-j0.4": "1.1.1",
     "tomlify-j0.4": "3.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -54,6 +54,11 @@ inherits@2:
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
 
+json5@2.2.3:
+  version "2.2.3"
+  resolved "https://registry.yarnpkg.com/json5/-/json5-2.2.3.tgz#78cd6f1a19bdc12b73db5ad0c61efd66c1e29283"
+  integrity sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==
+
 lodash.mergewith@4.6.2:
   version "4.6.2"
   resolved "https://registry.yarnpkg.com/lodash.mergewith/-/lodash.mergewith-4.6.2.tgz#617121f89ac55f59047c7aec1ccd6654c6590f55"


### PR DESCRIPTION
These files are treated the same as regular JSON files, but we can have comments in the files. It also supports a couple of [other features](https://www.npmjs.com/package/json5#summary-of-features) from ECMAScript 5.1.

This PR adds support for using them as the merge source (either plain JSON5 or patch files) as well as writing as JSON5.